### PR TITLE
Added promhttp import and fixed Handler error with promhttp.Handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ VERSION=latest
 
 all:
 	go build -o prometheus-example-app 
-	docker build -t sysdiglabs/prom-example:latest:$(VERSION) .
+	docker build -t sysdiglabs/prom-example:$(VERSION) .

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
+        "github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func main() {
@@ -21,7 +22,7 @@ func main() {
 
 	router := mux.NewRouter()
 	router.Handle("/sayhello/{name}", Sayhello(histogram))
-	router.Handle("/metrics", prometheus.Handler()) //Metrics endpoint for scrapping
+	router.Handle("/metrics", promhttp.Handler()) //Metrics endpoint for scrapping
 	router.Handle("/{anything}", Sayhello(histogram))
 	router.Handle("/", Sayhello(histogram))
 	//Registering the defined metric with Prometheus


### PR DESCRIPTION
Binary compilation is not working. The Handler function should be called from the promhttp package.
These are the changes proposed in this PR.
 - Added a new import for promhttp package.
 - Fixed the Handler call from this new package.
 - Fixed an issue in the Makefile. 